### PR TITLE
feat(contact): inline Formspree submission with confetti and transien…

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,32 @@ For questions about the website or Pulse COOP:
 ## 📄 License
 
 This project is part of Pulse COOP's open-source initiatives. Built with ❤️ by the Pulse COOP team.
+
+## Formspree Contact Form
+
+This project uses Formspree for contact submissions.
+
+### Environment variables
+
+Provide one of the following (client-exposed) environment variables:
+
+- `PUBLIC_FORMSPREE_FORM_ID` (Astro-friendly, recommended)
+- `NEXT_PUBLIC_FORM` (compatible with Vercel Formspree integration)
+
+Example `.env`:
+
+```
+PUBLIC_FORMSPREE_FORM_ID=your_formspree_form_id
+```
+
+### Where it’s used
+
+- Service: `src/lib/formspree.ts`
+- Form UI: `src/components/ContactForm.astro`
+- Section embedding: `src/components/ContactSection.astro`
+
+### How it works
+
+`ContactForm.astro` posts to Formspree via `submitToFormspree` using `fetch` to `https://formspree.io/f/<FORM_ID>` with `FormData`.
+
+If the env var is missing, the form will display an error on submit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/vite": "^4.1.11",
         "astro": "^5.12.8",
+        "canvas-confetti": "^1.9.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.537.0",
@@ -2064,6 +2065,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
       }
     },
     "node_modules/ccount": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.11",
     "astro": "^5.12.8",
+    "canvas-confetti": "^1.9.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.537.0",

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -1,0 +1,154 @@
+---
+const formspreeId = import.meta.env.PUBLIC_FORMSPREE_FORM_ID || import.meta.env.NEXT_PUBLIC_FORM;
+---
+
+<form id="contact-form" class="space-y-4" data-formspree-id={formspreeId || ''}>
+  <div id="contact-fields" class="space-y-4">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="flex flex-col gap-2">
+        <label for="name" class="text-sm text-muted-foreground">Name</label>
+        <input id="name" name="name" required placeholder="Your name" class="h-11 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" />
+      </div>
+      <div class="flex flex-col gap-2">
+        <label for="email" class="text-sm text-muted-foreground">Email</label>
+        <input id="email" name="email" type="email" required placeholder="you@example.com" class="h-11 rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" />
+      </div>
+    </div>
+    <div class="flex flex-col gap-2">
+      <label for="message" class="text-sm text-muted-foreground">Message</label>
+      <textarea id="message" name="message" rows="5" required placeholder="How can we help?" class="rounded-md border border-input bg-background p-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <button id="contact-submit" type="submit" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all h-10 px-4 border bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+        <svg class="hidden animate-spin size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke-width="4"></circle>
+          <path class="opacity-75" d="M4 12a8 8 0 018-8" stroke-width="4"></path>
+        </svg>
+        <span>Send</span>
+      </button>
+    </div>
+  </div>
+
+  <div id="contact-success" class="hidden rounded-xl border border-emerald-300/50 dark:border-emerald-600/40 bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 px-4 py-6 text-center transition-opacity">
+    <p class="text-base md:text-lg font-medium">Thanks for your message! 🤝</p>
+    <p class="text-sm text-emerald-600/80 dark:text-emerald-300/80 mt-1">We\'ll get back to you soon.</p>
+  </div>
+
+  { !formspreeId && (
+    <p class="text-xs text-destructive mt-2">Missing Formspree ID. Set PUBLIC_FORMSPREE_FORM_ID in your .env.local.</p>
+  )}
+</form>
+
+<script type="module">
+  // Load confetti dynamically from ESM CDN to avoid bundling issues
+  let confettiFn = null;
+  async function loadConfetti() {
+    if (confettiFn) return confettiFn;
+    const mod = await import('https://esm.sh/canvas-confetti@1');
+    confettiFn = mod.default || mod;
+    return confettiFn;
+  }
+
+  const form = document.getElementById('contact-form');
+  const fields = document.getElementById('contact-fields');
+  const successPanel = document.getElementById('contact-success');
+  const submitBtn = document.getElementById('contact-submit');
+  const spinner = submitBtn?.querySelector('svg');
+  const submitText = submitBtn?.querySelector('span');
+
+  let resetTimer;
+
+  function setSubmitting(isSubmitting) {
+    if (!submitBtn || !spinner || !submitText) return;
+    submitBtn.disabled = isSubmitting;
+    spinner.classList.toggle('hidden', !isSubmitting);
+    submitText.textContent = isSubmitting ? 'Sending...' : 'Send';
+  }
+
+  function showSuccessTransient() {
+    if (!fields || !successPanel) return;
+    fields.classList.add('hidden');
+    successPanel.classList.remove('hidden');
+    clearTimeout(resetTimer);
+    resetTimer = setTimeout(() => {
+      successPanel.classList.add('opacity-0');
+      setTimeout(() => {
+        successPanel.classList.add('hidden');
+        successPanel.classList.remove('opacity-0');
+        fields.classList.remove('hidden');
+      }, 200);
+    }, 3000);
+  }
+
+  async function fireConfetti() {
+    const confetti = await loadConfetti();
+    const end = Date.now() + 600;
+    const colors = ['#10b981','#3b82f6','#ef4444','#f59e0b','#22c55e'];
+    (function frame() {
+      confetti({ particleCount: 40, spread: 60, startVelocity: 35, ticks: 90, scalar: 0.9, origin: { y: 0.25 }, colors });
+      if (Date.now() < end) requestAnimationFrame(frame);
+    })();
+  }
+
+  async function submitToFormspreeInline(formId, data) {
+    if (!formId) {
+      return { ok: false, status: 500, error: 'Missing Formspree form id.' };
+    }
+    try {
+      const formData = new FormData();
+      formData.append('name', data.name);
+      formData.append('email', data.email);
+      formData.append('message', data.message);
+
+      const res = await fetch(`https://formspree.io/f/${formId}`, {
+        method: 'POST',
+        body: formData,
+        headers: { 'Accept': 'application/json' },
+      });
+      const body = await res.json().catch(() => undefined);
+      if (!res.ok) {
+        let errorMsg = 'Submission failed';
+        const errors = body?.errors;
+        if (Array.isArray(errors) && errors.length) {
+          errorMsg = errors.map(e => e.message).filter(Boolean).join('\n') || errorMsg;
+        }
+        return { ok: false, status: res.status, error: errorMsg, body };
+      }
+      return { ok: true, status: res.status, body };
+    } catch (err) {
+      return { ok: false, status: 0, error: 'Network error' };
+    }
+  }
+
+  if (form) {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const name = /** @type {HTMLInputElement|null} */(document.getElementById('name'));
+      const email = /** @type {HTMLInputElement|null} */(document.getElementById('email'));
+      const message = /** @type {HTMLTextAreaElement|null} */(document.getElementById('message'));
+      const formId = form.getAttribute('data-formspree-id');
+      if (!name || !email || !message) return false;
+
+      setSubmitting(true);
+      const res = await submitToFormspreeInline(formId, {
+        name: name.value.trim(),
+        email: email.value.trim(),
+        message: message.value.trim(),
+      });
+      setSubmitting(false);
+
+      if (res.ok) {
+        await fireConfetti();
+        form.reset();
+        showSuccessTransient();
+      } else {
+        alert(res.error || 'Something went wrong. Please try again later.');
+      }
+
+      return false;
+    }, { passive: false });
+  }
+</script>

--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -1,5 +1,6 @@
 ---
 // Contact Section Component
+import ContactForm from './ContactForm.astro';
 ---
 
 <!-- Contact Section -->
@@ -25,7 +26,7 @@
 		
 		<div class="group relative max-w-md mx-auto">
 			<div class="absolute inset-0 bg-gradient-to-br from-yellow-400/30 to-orange-400/30 dark:from-yellow-500/30 dark:to-orange-500/30 rounded-3xl blur-xl group-hover:blur-2xl transition-all duration-500"></div>
-			<div class="relative bg-card/90 backdrop-blur-sm p-10 rounded-3xl border border-yellow-200/50 dark:border-yellow-700/50 hover:border-orange-300/50 dark:hover:border-orange-600/50 transition-all duration-500">
+			<div class="relative bg-card/90 backdrop-blur-sm p-10 rounded-3xl border border-yellow-200/50 dark:border-yellow-700/50 hover:border-orange-300/50 dark:hover:border-orange-600/50 transition-all duration-500 text-left">
 				<div class="flex items-center justify-center mb-8">
 					<div class="w-16 h-16 bg-gradient-to-br from-orange-500 to-red-500 dark:from-orange-400 dark:to-red-400 rounded-2xl flex items-center justify-center group-hover:scale-105 transition-transform duration-300">
 						<svg class="w-7 h-7 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -34,13 +35,8 @@
 					</div>
 				</div>
 				
-				<h3 class="text-2xl font-bold text-foreground mb-8">Get in Touch</h3>
-				<a href="mailto:hello@pulse.coop" class="text-xl text-orange-700 dark:text-orange-400 font-semibold hover:text-red-800 dark:hover:text-red-400 transition-colors duration-300 group-hover:underline decoration-2 decoration-orange-500 dark:decoration-orange-400 underline-offset-4">
-					hello@pulse.coop
-				</a>
-				<p class="text-muted-foreground mt-8 text-sm leading-relaxed">
-					We'll get back to you as soon as possible
-				</p>
+				<h3 class="text-2xl font-bold text-foreground mb-6">Get in Touch</h3>
+				<ContactForm />
 			</div>
 		</div>
 	</div>

--- a/src/lib/formspree.ts
+++ b/src/lib/formspree.ts
@@ -1,0 +1,62 @@
+export type ContactFormData = {
+  name: string
+  email: string
+  message: string
+}
+
+export type FormspreeResponse = {
+  ok: boolean
+  status: number
+  body?: unknown
+  error?: string
+}
+
+function getFormspreeFormId(): string | undefined {
+  // Supports both Astro's PUBLIC_ convention and Vercel integration example
+  // @ts-ignore - allow access; Astro exposes PUBLIC_* to client
+  const astroPublic = (import.meta as any).env?.PUBLIC_FORMSPREE_FORM_ID as string | undefined
+  // @ts-ignore - allow access if provided
+  const vercelNextPublic = (import.meta as any).env?.NEXT_PUBLIC_FORM as string | undefined
+  return astroPublic || vercelNextPublic
+}
+
+export async function submitToFormspree(data: ContactFormData): Promise<FormspreeResponse> {
+  const formId = getFormspreeFormId()
+  if (!formId) {
+    return {
+      ok: false,
+      status: 500,
+      error:
+        'Missing Formspree form id. Set PUBLIC_FORMSPREE_FORM_ID (recommended) or NEXT_PUBLIC_FORM in your environment.'
+    }
+  }
+
+  try {
+    const formData = new FormData()
+    formData.append('name', data.name)
+    formData.append('email', data.email)
+    formData.append('message', data.message)
+
+    const res = await fetch(`https://formspree.io/f/${formId}`, {
+      method: 'POST',
+      body: formData,
+      headers: { 'Accept': 'application/json' },
+    })
+
+    const body = await res.json().catch(() => undefined)
+
+    if (!res.ok) {
+      let errorMsg = 'Submission failed'
+      // @ts-ignore
+      const errors = body?.errors as Array<{ message?: string }> | undefined
+      if (errors && errors.length) {
+        errorMsg = errors.map(e => e.message).filter(Boolean).join('\n') || errorMsg
+      }
+      return { ok: false, status: res.status, body, error: errorMsg }
+    }
+
+    return { ok: true, status: res.status, body }
+  } catch (error) {
+    return { ok: false, status: 0, error: error instanceof Error ? error.message : 'Network error' }
+  }
+}


### PR DESCRIPTION
…t success\n\n- Prevent redirect by removing native action/method\n- Inline fetch to Formspree using FormData and JSON accept\n- Load confetti via ESM CDN, show 3s success panel\n- Fix module import errors and 404s