### PR TITLE
Fix text clipping in 'Let's Work Together' heading

### DIFF
--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -13,7 +13,7 @@ import ContactForm from './ContactForm.astro';
 	
 	<div class="max-w-4xl mx-auto px-6 text-center relative z-10">
 		<div class="mb-12">
-			<h2 class="text-4xl md:text-5xl font-bold bg-gradient-to-r from-yellow-600 via-orange-600 to-red-600 dark:from-yellow-400 dark:via-orange-400 dark:to-red-400 bg-clip-text text-transparent mb-6 tracking-tight">
+			<h2 class="text-4xl md:text-5xl font-bold bg-gradient-to-r from-yellow-600 via-orange-600 to-red-600 dark:from-yellow-400 dark:via-orange-400 dark:to-red-400 bg-clip-text text-transparent mb-6 tracking-tight leading-tight pb-2">
 				Let's Work Together
 			</h2>
 			<div class="w-32 h-1 bg-gradient-to-r from-yellow-400 via-orange-400 to-red-400 dark:from-yellow-500 dark:via-orange-500 dark:to-red-500 mx-auto rounded-full"></div>


### PR DESCRIPTION
- Add leading-tight and pb-2 classes to prevent descender clipping
- Fix 'g' in 'Together' being cut off at bottom
- Ensure proper spacing for gradient text with bg-clip-text

Resolves visual issue where descenders in gradient headings were clipped.